### PR TITLE
feat: 記事詳細と一覧下に広告を再配置し、広告条件をnoAdへ統一

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -6,7 +6,7 @@ lastmod: 2026-05-03
 relatedContentLimit: 0
 heroStyle: "background"
 showTableOfContents: false
-showGoogleAd: false
+noAd: true
 showPagination: false
 ---
 

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -4,7 +4,7 @@ description: "プライバシーポリシー"
 date: 2019-02-28
 lastmod: 2023-11-29
 showTableOfContents: false
-showGoogleAd: false
+noAd: true
 showPagination: false
 ---
 

--- a/layouts/partials/body/google-ad.html
+++ b/layouts/partials/body/google-ad.html
@@ -1,5 +1,5 @@
-{{ if not .Params.noAd }}
-<h2>スポンサードリンク</h3>
+{{ if and (eq .Section "posts") (not .Params.noAd) }}
+<h2>スポンサードリンク</h2>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8480565306518637"
   crossorigin="anonymous"></script>
 <!-- rakutech-ad -->

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,0 +1,58 @@
+{{ if and (eq (.Scratch.Get "scope") "list") (eq .Section "posts") }}
+  <div class="mt-12">
+    {{ partial "body/google-ad.html" . }}
+  </div>
+{{ end }}
+
+{{- if gt .Paginator.TotalPages 1 -}}
+  <ul class="flex flex-row mt-8 justify-center">
+    {{- .Scratch.Set "paginator.ellipsed" false -}}
+    {{ if $.Paginator.HasPrev }}
+      <li>
+        <a
+          href="{{ $.Paginator.Prev.URL }}"
+          class="mx-1 block min-w-[1.8rem] rounded text-center hover:bg-primary-600 hover:text-neutral"
+          rel="prev"
+          >&larr;</a
+        >
+      </li>
+    {{ end }}
+    {{- range $.Paginator.Pagers -}}
+      {{- $right := sub .TotalPages .PageNumber -}}
+      {{- $showNumber := or (le .PageNumber 1) (eq $right 0) -}}
+      {{- $showNumber := or $showNumber (and (gt .PageNumber (sub $.Paginator.PageNumber 3)) (lt .PageNumber (add $.Paginator.PageNumber 3))) -}}
+      {{- if $showNumber -}}
+        {{- $.Scratch.Set "paginator.ellipsed" false -}}
+        {{- $.Scratch.Set "paginator.shouldEllipse" false -}}
+      {{- else -}}
+        {{- $.Scratch.Set "paginator.shouldEllipse" (not ($.Scratch.Get "paginator.ellipsed") ) -}}
+        {{- $.Scratch.Set "paginator.ellipsed" true -}}
+      {{- end -}}
+      {{- if $showNumber -}}
+        <li>
+          <a
+            href="{{ .URL }}"
+            class="{{ if eq . $.Paginator }}
+              bg-primary-200 dark:bg-primary-400 dark:text-neutral-800
+            {{ end }} mx-1 block min-w-[1.8rem] rounded text-center hover:bg-primary-600 hover:text-neutral"
+            >{{ .PageNumber }}</a
+          >
+        </li>
+      {{- else if ($.Scratch.Get "paginator.shouldEllipse") -}}
+        <li class="page-item ">
+          <span class="page-link" aria-hidden="true">&hellip;</span>
+        </li>
+      {{- end -}}
+    {{- end -}}
+    {{ if $.Paginator.HasNext }}
+      <li>
+        <a
+          href="{{ $.Paginator.Next.URL }}"
+          class="mx-1 block min-w-[1.8rem] rounded text-center hover:bg-primary-600 hover:text-neutral"
+          rel="next"
+          >&rarr;</a
+        >
+      </li>
+    {{ end }}
+  </ul>
+{{- end -}}

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,3 +1,5 @@
+{{ partial "body/google-ad.html" . }}
+
 {{ if .Params.showRelatedContent | default (.Site.Params.article.showRelatedContent | default false) }}
   {{ $limit := .Site.Params.article.relatedContentLimit | default 6 }}
   {{ $current := . }}


### PR DESCRIPTION
## Summary
- 記事詳細ページで関連記事の前に広告を表示するように変更し、広告の再表示を復元
- 記事一覧ページの最下部（ページネーション直前）にも広告を表示するため `pagination` partial をオーバーライド
- 広告表示条件を `noAd` に統一し、`posts` セクション限定にして About/Privacy への誤表示を防止

## Changes
- `layouts/partials/related.html` に広告 partial 呼び出しを追加
- `layouts/partials/pagination.html` を追加して一覧末尾に広告を挿入
- `layouts/partials/body/google-ad.html` の条件を `posts && !noAd` に変更し、見出しタグの閉じ忘れを修正
- `content/about/index.md` と `content/privacy.md` の `showGoogleAd: false` を `noAd: true` へ移行

## Verification
- `hugo` ビルド成功（既存のテーマ互換WARNのみ）